### PR TITLE
Fix extracting id from url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matters/matters-editor",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "The editor component.",
   "author": "Matters Lab",
   "homepage": "https://github.com/thematters/matters-editor",

--- a/src/matchers/createImage.ts
+++ b/src/matchers/createImage.ts
@@ -55,11 +55,14 @@ const createImageMatcher = (upload: any, assetDomain: string, siteDomain: string
   const srcOrg = delta.ops[0].insert.image
 
   let imageFigure
-  // don't upload if copying from matters internally
+  // don't upload if copying from your site internally
   // retrieve asset id from url
   const domain = extractDomain(assetDomain || '') || siteDomain
   if (srcOrg.indexOf(domain) !== -1) {
-    const assetId = srcOrg.split('/').slice(-2, -1)[0]
+    const assetId = (srcOrg.split('/').slice(-1)[0] || '').split('.')[0]
+    if (!assetId) {
+      return delta
+    }
 
     imageFigure = {
       src: srcOrg,


### PR DESCRIPTION
Fix extracting id from url when copying and pasting assets have been saved. 🦞