### PR TITLE
insert empty line at beginning if startsWith pre code-block

### DIFF
--- a/src/article.tsx
+++ b/src/article.tsx
@@ -57,8 +57,13 @@ export class MattersArticleEditor extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props)
+
+    let content = this.props.editorContent
+    if (content.match(/^\s*<pre +/)) {
+      content = '<p><br></p>' + content.trimLeft()
+    }
     this.state = {
-      content: this.props.editorContent,
+      content,
       mentionInstance: null,
       toolbarPosition: 0,
       toolbarVisible: false,


### PR DESCRIPTION
should be the ultimate fix #374 Code block eats up lines if it's added in the beginning of article content 5 pt bug

have tried many ways to remove this empty line after end of initialization, but does not work or have other complications
would be better to leave it, user can always delete this empty line before publishing

current sympton of #374 is losing all rich text formatting, all paragraphs (except the last one) are merged into the pre code-block, and hence losing format;

bottom line is not to lose all rich text formatting