### PR TITLE
chore: support Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,20 +18,20 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.19'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
       - name: Cache Dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node24-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node24-
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['18.19', '24']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.19'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
       - name: Cache Dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node${{ matrix.node-version }}-
 
       - name: Install Dependencies
         run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-unsafe-perm=true
 legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matters/matters-editor",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@matters/matters-editor",
-      "version": "0.3.1-alpha.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "2.8.0",
@@ -93,7 +93,7 @@
         "vitest": "^2.0.4"
       },
       "engines": {
-        "node": ">=18.19 <19.0"
+        "node": ">=18.19 <25.0.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matters/matters-editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Editor for matters.news",
   "author": "https://github.com/thematters",
   "homepage": "https://github.com/thematters/matters-editor",
@@ -9,7 +9,7 @@
     "url": "git@github.com:thematters/matters-editor.git"
   },
   "engines": {
-    "node": ">=18.19 <19.0"
+    "node": ">=18.19 <25.0.0"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- publish the next 0.3.x compatibility release as `@matters/matters-editor@0.3.2`
- relax `engines.node` to the transition-safe range `>=18.19 <25.0.0`
- run PR CI against both Node 18.19 and Node 24
- update publish workflow to Node 24 and remove obsolete npm `unsafe-perm`

## Validation
- `npm ci`
- `npm run lint`
- `npm run test` (4 files / 71 tests)
- `npm run build`
- packed `dist` package installed with `npm install --engine-strict` on Node 24 and `@matters/matters-editor/transformers` ran `html2md`

## Notes
This keeps the code and dependency graph unchanged. It avoids jumping to the registry's `1.0.3` artifact, which is not tagged as latest and has a different dependency shape.