### PR TITLE
Release: v0.3.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,20 +18,20 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.19'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
       - name: Cache Dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node24-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node24-
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['18.19', '24']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.19'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
       - name: Cache Dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-node${{ matrix.node-version }}-
 
       - name: Install Dependencies
         run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-unsafe-perm=true
 legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matters/matters-editor",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@matters/matters-editor",
-      "version": "0.3.1-alpha.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "2.8.0",
@@ -93,7 +93,7 @@
         "vitest": "^2.0.4"
       },
       "engines": {
-        "node": ">=18.19 <19.0"
+        "node": ">=18.19 <25.0.0"
       },
       "peerDependencies": {
         "react": ">=17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matters/matters-editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Editor for matters.news",
   "author": "https://github.com/thematters",
   "homepage": "https://github.com/thematters/matters-editor",
@@ -9,7 +9,7 @@
     "url": "git@github.com:thematters/matters-editor.git"
   },
   "engines": {
-    "node": ">=18.19 <19.0"
+    "node": ">=18.19 <25.0.0"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- release `@matters/matters-editor@0.3.2`
- includes Node 24 compatibility support from #519
- keeps runtime code/dependency graph unchanged from the Node 24 compatibility PR

## Release effect
Merging this PR into `master` triggers the existing publish workflow, which builds and publishes `./dist` to npm using `NPM_AUTH_TOKEN`.

## Validation already completed
- #519 CI passed on Node 18.19 and Node 24
- local `npm ci`, `npm run lint`, `npm run test`, `npm run build`
- packed dist installed on Node 24 with `npm install --engine-strict`
- downstream dry-run install completed for `matters-server` and `matters-web`

## Notes
After npm publishes `0.3.2`, update `matters-server` and `matters-web` lockfiles to consume it in their Node 24 PRs.