### PR TITLE
[codex] Run Node 24 checks on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  pull_request:
   push:
     branches-ignore:
       - develop
@@ -16,7 +17,7 @@ jobs:
         node-version: ['18.19', '24']
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Makes the existing Node 18.19 and Node 24 test matrix run on pull requests, and updates the checkout action in that workflow to `actions/checkout@v4`.

## Why

`matters-editor` is a shared package consumed by other Matters repos. It already has a Node 24 test matrix, but PRs should show that matrix directly before downstream repos move to Node 24.

This PR does not change package code, runtime requirements, or dependencies.

## Validation

- `npm ci`
- `npm run lint && npm run test`, 71 tests passed
- `npx -y node@24 ./node_modules/vitest/vitest.mjs --run`, 71 tests passed
- `npm run build`, completed with existing Rollup warnings

## Rollback

Revert this workflow-only commit. Runtime behavior and published package output are unchanged.
