### PR TITLE
Fix release publish workflow

### DIFF
--- a/.github/workflows/deploy_demo.yml
+++ b/.github/workflows/deploy_demo.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run build:demo
 
       - name: Upload production-ready build files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: production-files
           path: ./demo
@@ -36,7 +36,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-files
           path: ./demo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       # === `master` branch ===
       - name: Publish to NPM
         if: github.ref == 'refs/heads/master'
-        run: npm publish ./dist
+        run: npm publish ./dist --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Publish `@matters/matters-editor@0.3.3` with an explicit `latest` dist-tag so npm accepts the 0.3.x release line even though older 1.x versions exist in the registry.
- Update demo artifact upload/download actions from v3 to v4 to avoid the deprecated action failure on master.

## Validation

- `git diff --check`
- Commit hook ran `npm run lint`
- Commit hook ran `npm test`

## Context

#523 merged successfully, but the master publish workflow failed at `npm publish ./dist` because npm requires an explicit tag when publishing 0.3.3 after previously published 1.0.3.