### PR TITLE
Publish scoped package as public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       # === `master` branch ===
       - name: Publish to NPM
         if: github.ref == 'refs/heads/master'
-        run: npm publish ./dist --tag latest
+        run: npm publish ./dist --tag latest --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Add `--access public` to the `npm publish ./dist --tag latest` command for the scoped `@matters/matters-editor` package.

## Context

#524 fixed the missing explicit `latest` tag, but the next master publish still failed with npm 404 because scoped packages need public access specified during publish.

## Validation

- `git diff --check`
- Commit hook ran `npm run lint`
- Commit hook ran `npm test`